### PR TITLE
Updated gather_stock_time_series function

### DIFF
--- a/R/rintrinio.R
+++ b/R/rintrinio.R
@@ -244,25 +244,52 @@ gather_financial_statement_company_compare <- function(api_key, ticker, statemen
 #' @param ticker character the ticker symbol you would like to get stock data for
 #' @param start_date character optional the earliest date in the format of "%Y-%m-%d", e.g. "2019-12-31" to get data for
 #' @param end_date character optional the most recent date in the format of "%Y-%m-%d", e.g. "2019-12-31" to get data for
+#' @param allow_max_rows boolean optional if False, then only 100 rows will show in the output, otherwise up to 10000 rows will show (based on dates)
 #'
 #' @return a dataframe that contains stock data for the specified timeframe
 #'
 #' @examples
 #' gather_stock_time_series(api_key, 'AAPL', "2017-12-31", "2019-03-01")
-gather_stock_time_series <- function(api_key, ticker, start_date='', end_date='') {
+gather_stock_time_series <- function(api_key, ticker, start_date='', end_date='', allow_max_rows=FALSE) {
+  
+  # set up allow_max_rows output
+  if (allow_max_rows == FALSE) {
+    rows = 100
+  }
+  else {
+    rows = 10000
+  }
   
   # set up options
   if (start_date != '' & end_date != '') {
-    opts <- list(start_date = as.Date(start_date), end_date = as.Date(end_date), page_size = 10000)
+    t <- try({
+      opts <- list(start_date = as.Date(start_date), end_date = as.Date(end_date), page_size = rows)
+    }, silent=T)
+    if("try-error" %in% class(t)) {
+      return("Invalid Date format: date must be a string in the format %Y-%m-%d")
+    }
+    if (start_date >= end_date) {
+      return("Invalid Input: end_date must be later than start_date")
+    }
   }
   else if (start_date != '') {
-    opts <- list(start_date = as.Date(start_date), page_size = 10000)
+    t <- try({
+      opts <- list(start_date = as.Date(start_date), page_size = rows)
+    }, silent=T)
+    if("try-error" %in% class(t)) {
+      return("Invalid Date format: date must be a string in the format %Y-%m-%d")
+    }
   }
   else if (end_date != '') {
-    opts <- list(end_date = as.Date(end_date), page_size = 10000)
+    t <- try({
+      opts <- list(end_date = as.Date(end_date), page_size = rows)
+    }, silent=T)
+    if("try-error" %in% class(t)) {
+      return("Invalid Date format: date must be a string in the format %Y-%m-%d")
+    }
   }
   else {
-    opts <- list(page_size = 10000)
+    opts <- list(page_size = rows)
   }
   
   # throw an error if the API Key is Invalid

--- a/tests/testthat/test-gather_stock_time_series.R
+++ b/tests/testthat/test-gather_stock_time_series.R
@@ -1,6 +1,6 @@
 # test functions for gather_stock_time_series() function
 
-library(tidyverse)
+library(dplyr)
 library(IntrinioSDK)
 library(testthat)
 

--- a/tests/testthat/test-gather_stock_time_series.R
+++ b/tests/testthat/test-gather_stock_time_series.R
@@ -17,8 +17,32 @@ test_that("The default return type is not a dataframe", {
 
 # test that you get an error when you put in an incorrect API key
 test_that("API Error is not working as expected", {
-  msg <- "Incorrect API Key - please input a valid API key as a string"
+  msg <- "Invalid API Key: please input a valid API key as a string"
   expect_equal(gather_stock_time_series("not an API Key!!!!", ticker), msg)
+})
+
+# test that you get an error when you put in an invalid date format for start_date
+test_that("Date format error is not working as expected", {
+  msg <- "Invalid Date format: date must be a string in the format %Y-%m-%d"
+  expect_equal(gather_stock_time_series(api_key, ticker, start_date = "2"), msg)
+})
+
+# test that you get an error when you put in an invalid date format for end_date
+test_that("Date format error is not working as expected", {
+  msg <- "Invalid Date format: date must be a string in the format %Y-%m-%d"
+  expect_equal(gather_stock_time_series(api_key, ticker, end_date = "2"), msg)
+})
+
+# test that you get an error when you put in an invalid date format for start_date and end_date
+test_that("Date format error is not working as expected", {
+  msg <- "Invalid Date format: date must be a string in the format %Y-%m-%d"
+  expect_equal(gather_stock_time_series(api_key, ticker, start_date = "2", end_date = 123), msg)
+})
+
+# test that you get an error when your end date is before your start date
+test_that("Date order error is not working as expected", {
+  msg <- "Invalid Input: end_date must be later than start_date"
+  expect_equal(gather_stock_time_series(api_key, ticker, start_date = "2020-01-30", end_date = "2020-01-01"), msg)
 })
 
 # test that you get a valid output shape when you put in no start date
@@ -34,6 +58,16 @@ test_that("Output shape without an end date is not valid", {
 # test that you get a valid output shape when you don't put in a start or end date
 test_that("Output shape without any dates is not valid", {
   expect_gt(dim(gather_stock_time_series(api_key, ticker))[1], 0)
+})
+
+# test that by default you get max 100 rows
+test_that("allow_max_rows default argument is not working as expected", {
+  expect_equal(dim(gather_stock_time_series(api_key, ticker))[1], 100)
+})
+
+# test that you can get more than 100 rows 
+test_that("allow_max_rows default argument is not working as expected", {
+  expect_gt(dim(gather_stock_time_series(api_key, ticker, start_date = "2019-01-12", allow_max_rows = TRUE))[1], 100)
 })
 
 # test that you get valid output values


### PR DESCRIPTION
- added allow_max_rows argument to address known free API limitation
- added errors for invalid date formats
- added errors for when start date is after end date
- added tests for cases above